### PR TITLE
Use python 3.13

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -20,15 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'    
-
-      - name: Install system packages
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get install libpython3.9 libtinfo5
+          python-version: '3.13'    
 
       - name: Activate vcpkg
         uses: ARM-software/cmsis-actions/vcpkg@v1

--- a/.github/workflows/basic_w_report.yml
+++ b/.github/workflows/basic_w_report.yml
@@ -22,18 +22,12 @@ jobs:
         uses: actions/checkout@v6
 
       # Install Python used by the report utility
-      - name: Setup Python 3.10
+      - name: Setup Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - run: 
           pip install junit_reporter
-
-      # Install system packages required by FVP VSI extensions
-      - name: Install system packages
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get install libpython3.9 libtinfo5
          
       # Install vcpkg tools from the vcpkg-configuration.json and activate an Arm tools license
       - name: Activate vcpkg


### PR DESCRIPTION
Latest version of FVP models do not require unsupported python 3.9 - using python 3.13 instead